### PR TITLE
fix: use new officer function docx_current_block_xml()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Maintainer: Zachary Colburn <zcolburn@gmail.com>
 Description: It is sometimes necessary to create documentation for all files in a directory. Doing so by hand can be very tedious. This task is made fast and reproducible using the functionality of 'documenter'. It aggregates all text files in a directory and its subdirectories into a single word document in a semi-automated fashion.
 License: MIT + file LICENSE
 Encoding: UTF-8
-Imports: officer,
+Imports: officer (>= 0.5.0),
     magrittr,
     htmltools,
     xml2,

--- a/R/insert_paragraphs.R
+++ b/R/insert_paragraphs.R
@@ -23,7 +23,7 @@ insert_paragraphs <- function(
   iteration <- 0
   for(i in vec){
     officer::cursor_end(denv$docx)
-    cursor_pos <- denv$docx$doc_obj$get_at_cursor()
+    cursor_pos <- officer::docx_current_block_xml(denv$docx)
     iteration <- iteration + 1
     # Retrieve text.
     string <- i


### PR DESCRIPTION
Hello

New officer version `0.5.0` is now on cran and your package need a quick fix to make it working properly with latest officer version.

Instead of using internals `...$doc_obj$get_at_cursor()`, you should now use `docx_current_block_xml(denv$docx)` and the behavior will be as expected. Sorry for the change but there were issues to fix and this usage of internals made the change on CRAN harder than expected. `docx_current_block_xml(denv$docx)` is an exported function and will be maintained :)

KR
David